### PR TITLE
add: strict command feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ result = program
   .register('abcd', function(args) {
     console.log('just do', args)
   })
+  .register({ command: 'restore', equals: true }, function(args) {
+    console.log('restore', args)
+  })
   .register('args', function(args) {
     args = minimist(args)
     console.log('just do', args)
@@ -43,6 +46,15 @@ Moreover, little spelling mistakes are corrected too:
 
 ```
 node example.js abcs cod
+```
+
+If you want that the command must be strict equals, you can register the
+command with the json configuration:
+
+```js
+  program.register({ command: 'restore', equals: true }, function(args) {
+    console.log('restore', args)
+  })
 ```
 
 Acknowledgements

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you want that the command must be strict equals, you can register the
 command with the json configuration:
 
 ```js
-  program.register({ command: 'restore', equals: true }, function(args) {
+  program.register({ command: 'restore', strict: true }, function(args) {
     console.log('restore', args)
   })
 ```

--- a/example.js
+++ b/example.js
@@ -1,23 +1,23 @@
 
 var program = require('./')()
-  , minimist = require('minimist')
-  , result
+var minimist = require('minimist')
+var result
 
 result = program
-  .register('abcd', function(args) {
+  .register('abcd', function (args) {
     console.log('just do', args)
   })
-  .register({ command: 'restore', strict: true }, function(args) {
+  .register({ command: 'restore', strict: true }, function (args) {
     console.log('restore', args)
   })
-  .register('args', function(args) {
+  .register('args', function (args) {
     args = minimist(args)
     console.log('just do', args)
   })
-  .register('abcde code', function(args) {
+  .register('abcde code', function (args) {
     console.log('doing something', args)
   })
-  .register('another command', function(args) {
+  .register('another command', function (args) {
     console.log('anothering', args)
   })
   .parse(process.argv.splice(2))

--- a/example.js
+++ b/example.js
@@ -7,6 +7,9 @@ result = program
   .register('abcd', function(args) {
     console.log('just do', args)
   })
+  .register({ command: 'restore', equals: true }, function(args) {
+    console.log('restore', args)
+  })
   .register('args', function(args) {
     args = minimist(args)
     console.log('just do', args)

--- a/example.js
+++ b/example.js
@@ -7,7 +7,7 @@ result = program
   .register('abcd', function(args) {
     console.log('just do', args)
   })
-  .register({ command: 'restore', equals: true }, function(args) {
+  .register({ command: 'restore', strict: true }, function(args) {
     console.log('restore', args)
   })
   .register('args', function(args) {

--- a/index.js
+++ b/index.js
@@ -64,7 +64,13 @@ function commist() {
     return args
   }
 
-  function register(command, func) {
+  function register(inputCommand, func) {
+    var command = inputCommand
+    var strict = false
+    if(typeof command === 'object'){
+      command = inputCommand.command
+      strict = inputCommand.equals || false
+    }
     var matching  = lookup(command)
 
     matching.forEach(function(match) {
@@ -72,7 +78,7 @@ function commist() {
         throw new Error('command already registered: ' + command)
     })
 
-    commands.push(new Command(command, func))
+    commands.push(new Command(command, strict, func))
 
     return this
   }
@@ -84,8 +90,9 @@ function commist() {
   }
 }
 
-function Command(string, func) {
+function Command(string, strict, func) {
   this.string   = string
+  this.strict   = strict
   this.parts    = string.split(' ')
   this.length   = this.parts.length
   this.func     = func
@@ -107,9 +114,13 @@ Command.prototype.match = function match(string) {
 function CommandMatch(cmd, array) {
   this.cmd = cmd
   this.distances = cmd.parts.map(function(elem, i) {
-    if (array[i] !== undefined)
-      return leven(elem, array[i])
-    else
+    if (array[i] !== undefined) {
+      if(cmd.strict) {
+        return elem === array[i] ? 0 : undefined
+      } else {
+        return leven(elem, array[i])
+      }
+    } else
       return undefined
   }).filter(function(distance, i) {
     return distance !== undefined && distance < cmd.parts[i].length - 2

--- a/index.js
+++ b/index.js
@@ -65,20 +65,24 @@ function commist() {
   }
 
   function register(inputCommand, func) {
-    var command = inputCommand
-    var strict = false
-    if(typeof command === 'object'){
-      command = inputCommand.command
-      strict = inputCommand.equals || false
+    var commandOptions = {
+      command: inputCommand,
+      strict: false,
+      func: func
     }
-    var matching  = lookup(command)
+
+    if(typeof inputCommand === 'object'){
+      commandOptions = Object.assign(commandOptions, inputCommand)
+    }
+
+    var matching  = lookup(commandOptions.command)
 
     matching.forEach(function(match) {
-      if (match.string === command)
-        throw new Error('command already registered: ' + command)
+      if (match.string === commandOptions.command)
+        throw new Error('command already registered: ' + commandOptions.command)
     })
 
-    commands.push(new Command(command, strict, func))
+    commands.push(new Command(commandOptions))
 
     return this
   }
@@ -90,12 +94,12 @@ function commist() {
   }
 }
 
-function Command(string, strict, func) {
-  this.string   = string
-  this.strict   = strict
-  this.parts    = string.split(' ')
+function Command(options) {
+  this.string   = options.command
+  this.strict   = options.strict
+  this.parts    = this.string.split(' ')
   this.length   = this.parts.length
-  this.func     = func
+  this.func     = options.func
 
   this.parts.forEach(function(part) {
     if (part.length < 3)

--- a/index.js
+++ b/index.js
@@ -22,36 +22,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
-'use strict';
+'use strict'
 
 var leven = require('leven')
 
-function commist() {
-
+function commist () {
   var commands = []
 
-  function lookup(array) {
-    if (typeof array === 'string')
-      array = array.split(' ')
+  function lookup (array) {
+    if (typeof array === 'string') { array = array.split(' ') }
 
-    return commands.map(function(cmd) {
+    return commands.map(function (cmd) {
       return cmd.match(array)
-    }).filter(function(match) {
+    }).filter(function (match) {
       return match.partsNotMatched === 0
-    }).sort(function(a, b) {
-      if (a.inputNotMatched > b.inputNotMatched)
-        return 1
+    }).sort(function (a, b) {
+      if (a.inputNotMatched > b.inputNotMatched) { return 1 }
 
-      if (a.inputNotMatched === b.inputNotMatched && a.totalDistance > b.totalDistance)
-        return 1
+      if (a.inputNotMatched === b.inputNotMatched && a.totalDistance > b.totalDistance) { return 1 }
 
       return -1
-    }).map(function(match) {
+    }).map(function (match) {
       return match.cmd
     })
   }
 
-  function parse(args) {
+  function parse (args) {
     var matching = lookup(args)
 
     if (matching.length > 0) {
@@ -64,22 +60,21 @@ function commist() {
     return args
   }
 
-  function register(inputCommand, func) {
+  function register (inputCommand, func) {
     var commandOptions = {
       command: inputCommand,
       strict: false,
       func: func
     }
 
-    if(typeof inputCommand === 'object'){
+    if (typeof inputCommand === 'object') {
       commandOptions = Object.assign(commandOptions, inputCommand)
     }
 
-    var matching  = lookup(commandOptions.command)
+    var matching = lookup(commandOptions.command)
 
-    matching.forEach(function(match) {
-      if (match.string === commandOptions.command)
-        throw new Error('command already registered: ' + commandOptions.command)
+    matching.forEach(function (match) {
+      if (match.string === commandOptions.command) { throw new Error('command already registered: ' + commandOptions.command) }
     })
 
     commands.push(new Command(commandOptions))
@@ -88,51 +83,49 @@ function commist() {
   }
 
   return {
-      register: register
-    , parse: parse
-    , lookup: lookup
+    register: register,
+    parse: parse,
+    lookup: lookup
   }
 }
 
-function Command(options) {
-  this.string   = options.command
-  this.strict   = options.strict
-  this.parts    = this.string.split(' ')
-  this.length   = this.parts.length
-  this.func     = options.func
+function Command (options) {
+  this.string = options.command
+  this.strict = options.strict
+  this.parts = this.string.split(' ')
+  this.length = this.parts.length
+  this.func = options.func
 
-  this.parts.forEach(function(part) {
-    if (part.length < 3)
-      throw new Error('command words must be at least 3 chars: ' + command)
+  this.parts.forEach(function (part) {
+    if (part.length < 3) { throw new Error('command words must be at least 3 chars: ' + options.command) }
   })
 }
 
-Command.prototype.call = function call(argv) {
+Command.prototype.call = function call (argv) {
   this.func(argv.slice(this.length))
 }
 
-Command.prototype.match = function match(string) {
+Command.prototype.match = function match (string) {
   return new CommandMatch(this, string)
 }
 
-function CommandMatch(cmd, array) {
+function CommandMatch (cmd, array) {
   this.cmd = cmd
-  this.distances = cmd.parts.map(function(elem, i) {
+  this.distances = cmd.parts.map(function (elem, i) {
     if (array[i] !== undefined) {
-      if(cmd.strict) {
+      if (cmd.strict) {
         return elem === array[i] ? 0 : undefined
       } else {
         return leven(elem, array[i])
       }
-    } else
-      return undefined
-  }).filter(function(distance, i) {
+    } else { return undefined }
+  }).filter(function (distance, i) {
     return distance !== undefined && distance < cmd.parts[i].length - 2
   })
 
   this.partsNotMatched = cmd.length - this.distances.length
   this.inputNotMatched = array.length - this.distances.length
-  this.totalDistance = this.distances.reduce(function(acc, i) { return acc + i }, 0)
+  this.totalDistance = this.distances.reduce(function (acc, i) { return acc + i }, 0)
 }
 
 module.exports = commist

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Build your commands on minimist!",
   "main": "index.js",
   "scripts": {
-    "test": "tap test.js"
+    "test": "standard && tap test.js"
   },
   "pre-commit": "test",
   "repository": {
@@ -24,6 +24,7 @@
   "devDependencies": {
     "minimist": "^1.1.0",
     "pre-commit": "0.0.9",
+    "standard": "^12.0.1",
     "tape": "^3.0.3"
   }
 }

--- a/test.js
+++ b/test.js
@@ -149,8 +149,8 @@ test('looking up strict commands', function(t) {
   function noop1() {}
   function noop2() {}
 
-  program.register({ command: 'restore', equals: true }, noop1)
-  program.register({ command: 'rest', equals: true }, noop2)
+  program.register({ command: 'restore', strict: true }, noop1)
+  program.register({ command: 'rest', strict: true }, noop2)
 
   t.equal(program.lookup('restore')[0].func, noop1)
   t.equal(program.lookup('rest')[0].func, noop2)

--- a/test.js
+++ b/test.js
@@ -143,6 +143,22 @@ test('looking up commands with abbreviations', function(t) {
   t.end()
 })
 
+test('looking up strict commands', function(t) {
+  var program = commist()
+
+  function noop1() {}
+  function noop2() {}
+
+  program.register({ command: 'restore', equals: true }, noop1)
+  program.register({ command: 'rest', equals: true }, noop2)
+
+  t.equal(program.lookup('restore')[0].func, noop1)
+  t.equal(program.lookup('rest')[0].func, noop2)
+  t.equal(program.lookup('remove')[0], undefined)
+
+  t.end()
+})
+
 test('executing commands from abbreviations', function(t) {
   t.plan(1)
 

--- a/test.js
+++ b/test.js
@@ -1,15 +1,16 @@
 
-var test      = require('tape').test
-  , commist   = require('./')
-  , minimist  = require('minimist')
+var test = require('tape').test
 
-test('registering a command', function(t) {
+var commist = require('./')
+
+test('registering a command', function (t) {
   t.plan(2)
 
   var program = commist()
-    , result
 
-  program.register('hello', function(args) {
+  var result
+
+  program.register('hello', function (args) {
     t.deepEqual(args, ['a', '-x', '23'])
   })
 
@@ -18,79 +19,74 @@ test('registering a command', function(t) {
   t.notOk(result, 'must return null, the command have been handled')
 })
 
-test('registering two commands', function(t) {
+test('registering two commands', function (t) {
   t.plan(1)
 
   var program = commist()
-    , result
 
-  program.register('hello', function(args) {
+  program.register('hello', function (args) {
     t.ok(false, 'must pick the right command')
   })
 
-  program.register('world', function(args) {
+  program.register('world', function (args) {
     t.deepEqual(args, ['a', '-x', '23'])
   })
 
   program.parse(['world', 'a', '-x', '23'])
 })
 
-test('registering two commands (bis)', function(t) {
+test('registering two commands (bis)', function (t) {
   t.plan(1)
 
   var program = commist()
-    , result
 
-  program.register('hello', function(args) {
+  program.register('hello', function (args) {
     t.deepEqual(args, ['a', '-x', '23'])
   })
 
-  program.register('world', function(args) {
+  program.register('world', function (args) {
     t.ok(false, 'must pick the right command')
   })
 
   program.parse(['hello', 'a', '-x', '23'])
 })
 
-test('registering two words commands', function(t) {
+test('registering two words commands', function (t) {
   t.plan(1)
 
   var program = commist()
-    , result
 
-  program.register('hello', function(args) {
+  program.register('hello', function (args) {
     t.ok(false, 'must pick the right command')
   })
 
-  program.register('hello world', function(args) {
+  program.register('hello world', function (args) {
     t.deepEqual(args, ['a', '-x', '23'])
   })
 
   program.parse(['hello', 'world', 'a', '-x', '23'])
 })
 
-test('registering two words commands (bis)', function(t) {
+test('registering two words commands (bis)', function (t) {
   t.plan(1)
 
   var program = commist()
-    , result
 
-  program.register('hello', function(args) {
+  program.register('hello', function (args) {
     t.deepEqual(args, ['a', '-x', '23'])
   })
 
-  program.register('hello world', function(args) {
+  program.register('hello world', function (args) {
     t.ok(false, 'must pick the right command')
   })
 
   program.parse(['hello', 'a', '-x', '23'])
 })
 
-test('registering ambiguous commands throws exception', function(t) {
+test('registering ambiguous commands throws exception', function (t) {
   var program = commist()
-    , result
 
-  function noop() {}
+  function noop () {}
 
   program.register('hello', noop)
   program.register('hello world', noop)
@@ -99,19 +95,18 @@ test('registering ambiguous commands throws exception', function(t) {
   try {
     program.register('hello world', noop)
     t.ok(false, 'must throw if double-registering the same command')
-  } catch(err) {
+  } catch (err) {
   }
 
   t.end()
 })
 
-test('looking up commands', function(t) {
+test('looking up commands', function (t) {
   var program = commist()
-    , result
 
-  function noop1() {}
-  function noop2() {}
-  function noop3() {}
+  function noop1 () {}
+  function noop2 () {}
+  function noop3 () {}
 
   program.register('hello', noop1)
   program.register('hello world matteo', noop3)
@@ -124,13 +119,12 @@ test('looking up commands', function(t) {
   t.end()
 })
 
-test('looking up commands with abbreviations', function(t) {
+test('looking up commands with abbreviations', function (t) {
   var program = commist()
-    , result
 
-  function noop1() {}
-  function noop2() {}
-  function noop3() {}
+  function noop1 () {}
+  function noop2 () {}
+  function noop3 () {}
 
   program.register('hello', noop1)
   program.register('hello world matteo', noop3)
@@ -143,11 +137,11 @@ test('looking up commands with abbreviations', function(t) {
   t.end()
 })
 
-test('looking up strict commands', function(t) {
+test('looking up strict commands', function (t) {
   var program = commist()
 
-  function noop1() {}
-  function noop2() {}
+  function noop1 () {}
+  function noop2 () {}
 
   program.register({ command: 'restore', strict: true }, noop1)
   program.register({ command: 'rest', strict: true }, noop2)
@@ -159,48 +153,45 @@ test('looking up strict commands', function(t) {
   t.end()
 })
 
-test('executing commands from abbreviations', function(t) {
+test('executing commands from abbreviations', function (t) {
   t.plan(1)
 
   var program = commist()
-    , result
 
-  program.register('hello', function(args) {
+  program.register('hello', function (args) {
     t.deepEqual(args, ['a', '-x', '23'])
   })
 
-  program.register('hello world', function(args) {
+  program.register('hello world', function (args) {
     t.ok(false, 'must pick the right command')
   })
 
   program.parse(['hel', 'a', '-x', '23'])
 })
 
-test('a command must be at least 3 chars', function(t) {
+test('a command must be at least 3 chars', function (t) {
   var program = commist()
-    , result
 
-  function noop1() {}
+  function noop1 () {}
 
   try {
     program.register('h', noop1)
     t.ok(false, 'not thrown')
-  } catch(err) {
+  } catch (err) {
   }
 
   t.end()
 })
 
-test('a command part must be at least 3 chars', function(t) {
+test('a command part must be at least 3 chars', function (t) {
   var program = commist()
-    , result
 
-  function noop1() {}
+  function noop1 () {}
 
   try {
     program.register('h b', noop1)
     t.ok(false, 'not thrown')
-  } catch(err) {
+  } catch (err) {
   }
 
   t.end()


### PR DESCRIPTION
Hi,
I was using this lib, but I found that in some cases the Levenshtein distance is not so helpful: I have set a `restore` command that is trigger when I write `remove`.

This PR would like to add the possibility to choose if some commands need to be strict equals without using `leven`.

I would appreciate any feedback