### PR TITLE
Add parseAsync for handling asynchronous commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,16 @@ which let you await on registered commands execution.
 
 const program = require('commist')()
 
-await program
+const result = await program
   .register('abcd', async function(args) {
     await executeCommand(args)
     await doOtherStuff()
   })
   .parseAsync(process.argv.splice(2))
-  .then(() => {
-    console.log('command executed correctly')
-  })
-  .catch((result) => {
-    console.log('no command called, args', result)
-  })
+
+if (result) {
+  console.log('no command called, args', result)
+}
 ```
 
 When calling _commist_ programs, you can abbreviate down to three char

--- a/README.md
+++ b/README.md
@@ -32,6 +32,28 @@ if (result) {
 }
 ```
 
+To handle `async` operations, use `parseAsync` instead,
+which let you await on registered commands execution.
+
+```js
+'use strict'
+
+const program = require('commist')()
+
+await program
+  .register('abcd', async function(args) {
+    await executeCommand(args)
+    await doOtherStuff()
+  })
+  .parseAsync(process.argv.splice(2))
+  .then(() => {
+    console.log('command executed correctly')
+  })
+  .catch((result) => {
+    console.log('no command called, args', result)
+  })
+```
+
 When calling _commist_ programs, you can abbreviate down to three char
 words. In the above example, these are valid commands:
 

--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ function commist (opts) {
       return null
     }
 
-    return Promise.reject(args)
+    return args
   }
 
   function register (inputCommand, func) {

--- a/index.js
+++ b/index.js
@@ -32,9 +32,7 @@ function commist (opts) {
   const maxDistance = opts.maxDistance || Infinity
 
   function lookup (array) {
-    if (typeof array === 'string') {
-      array = array.split(' ')
-    }
+    if (typeof array === 'string') { array = array.split(' ') }
 
     let res = commands.map(function (cmd) {
       return cmd.match(array)
@@ -50,16 +48,9 @@ function commist (opts) {
     })
 
     res = res.sort(function (a, b) {
-      if (a.inputNotMatched > b.inputNotMatched) {
-        return 1
-      }
+      if (a.inputNotMatched > b.inputNotMatched) { return 1 }
 
-      if (
-        a.inputNotMatched === b.inputNotMatched &&
-        a.totalDistance > b.totalDistance
-      ) {
-        return 1
-      }
+      if (a.inputNotMatched === b.inputNotMatched && a.totalDistance > b.totalDistance) { return 1 }
 
       return -1
     })
@@ -90,7 +81,7 @@ function commist (opts) {
     if (matching.length > 0) {
       await matching[0].call(args)
       // return null to indicate there is nothing left to do
-      return Promise.resolve(null)
+      return null
     }
 
     return Promise.reject(args)
@@ -110,11 +101,7 @@ function commist (opts) {
     const matching = lookup(commandOptions.command)
 
     matching.forEach(function (match) {
-      if (match.string === commandOptions.command) {
-        throw new Error(
-          'command already registered: ' + commandOptions.command
-        )
-      }
+      if (match.string === commandOptions.command) { throw new Error('command already registered: ' + commandOptions.command) }
     })
 
     commands.push(new Command(commandOptions))
@@ -148,28 +135,21 @@ Command.prototype.match = function match (string) {
 
 function CommandMatch (cmd, array) {
   this.cmd = cmd
-  this.distances = cmd.parts
-    .map(function (elem, i) {
-      if (array[i] !== undefined) {
-        if (cmd.strict) {
-          return elem === array[i] ? 0 : undefined
-        } else {
-          return leven(elem, array[i])
-        }
+  this.distances = cmd.parts.map(function (elem, i) {
+    if (array[i] !== undefined) {
+      if (cmd.strict) {
+        return elem === array[i] ? 0 : undefined
       } else {
-        return undefined
+        return leven(elem, array[i])
       }
-    })
-    .filter(function (distance, i) {
-      return distance !== undefined && distance < cmd.parts[i].length
-    })
+    } else { return undefined }
+  }).filter(function (distance, i) {
+    return distance !== undefined && distance < cmd.parts[i].length
+  })
 
   this.partsNotMatched = cmd.length - this.distances.length
   this.inputNotMatched = array.length - this.distances.length
-  this.totalDistance = this.distances.reduce(function (acc, i) {
-    return acc + i
-  }, 0)
-  // console.log(this, array)
+  this.totalDistance = this.distances.reduce(function (acc, i) { return acc + i }, 0)
 }
 
 module.exports = commist

--- a/test.js
+++ b/test.js
@@ -95,8 +95,7 @@ test('registering ambiguous commands throws exception', function (t) {
   try {
     program.register('hello world', noop)
     t.ok(false, 'must throw if double-registering the same command')
-  } catch (err) {
-  }
+  } catch (err) {}
 
   t.end()
 })
@@ -169,6 +168,85 @@ test('executing commands from abbreviations', function (t) {
   program.parse(['hel', 'a', '-x', '23'])
 })
 
+test('executing async command', function (t) {
+  t.plan(1)
+
+  const program = commist()
+
+  program.register('hello', async function (args) {
+    t.deepEqual(args, ['a', '-x', '23'])
+  })
+
+  program.parseAsync(['hello', 'a', '-x', '23'])
+})
+
+test('async execution resolves when correctly matched one', function (t) {
+  t.plan(1)
+
+  const program = commist()
+
+  program.register('hello', async function () {
+    return 1337
+  })
+
+  program.parseAsync(['hello', 'a', '-x', '23']).then((result) => {
+    t.equal(result, null)
+  })
+})
+
+test('async execution rejects with args if no commands matched', function (t) {
+  t.plan(1)
+
+  const program = commist()
+
+  program.register('hello', async function () {
+    t.ok(false, 'command should not be picked')
+  })
+
+  program.parseAsync(['whoops', 'a', '-x', '23']).catch((args) => {
+    t.deepEqual(args, ['whoops', 'a', '-x', '23'])
+  })
+})
+
+test('async execution should wait intil registered command finishes', function (t) {
+  t.plan(1)
+
+  const program = commist()
+
+  program.register('hello', async function () {
+    const res = await Promise.resolve(42)
+    return res
+  })
+
+  program.parseAsync(['hello', 'a', '-x', '23']).then((result) => {
+    t.equal(result, null)
+  })
+})
+
+test('async execution should work with sync commands', function (t) {
+  t.plan(1)
+
+  const program = commist()
+
+  program.register('hello', function (args) {
+    t.deepEqual(args, ['a', '-x', '23'])
+  })
+
+  program.parseAsync(['hello', 'a', '-x', '23'])
+})
+
+test('sync execution should work with async commands', function (t) {
+  t.plan(1)
+
+  const program = commist()
+
+  program.register('hello', async function (args) {
+    t.deepEqual(args, ['a', '-x', '23'])
+  })
+
+  program.parse(['hello', 'a', '-x', '23'])
+})
+
 test('one char command', function (t) {
   const program = commist()
 
@@ -234,7 +312,10 @@ test('leven', function (t) {
   t.is(leven('sturgeon', 'urgently'), 6)
   t.is(leven('levenshtein', 'frankenstein'), 6)
   t.is(leven('distance', 'difference'), 5)
-  t.is(leven('因為我是中國人所以我會說中文', '因為我是英國人所以我會說英文'), 2)
+  t.is(
+    leven('因為我是中國人所以我會說中文', '因為我是英國人所以我會說英文'),
+    2
+  )
   t.end()
 })
 

--- a/test.js
+++ b/test.js
@@ -195,7 +195,7 @@ test('async execution resolves when correctly matched one', function (t) {
   })
 })
 
-test('async execution rejects with args if no commands matched', function (t) {
+test('async execution resolves with args if no commands matched', function (t) {
   t.plan(1)
 
   const program = commist()
@@ -204,7 +204,7 @@ test('async execution rejects with args if no commands matched', function (t) {
     t.ok(false, 'command should not be picked')
   })
 
-  program.parseAsync(['whoops', 'a', '-x', '23']).catch((args) => {
+  program.parseAsync(['whoops', 'a', '-x', '23']).then((args) => {
     t.deepEqual(args, ['whoops', 'a', '-x', '23'])
   })
 })

--- a/test.js
+++ b/test.js
@@ -95,7 +95,8 @@ test('registering ambiguous commands throws exception', function (t) {
   try {
     program.register('hello world', noop)
     t.ok(false, 'must throw if double-registering the same command')
-  } catch (err) {}
+  } catch (err) {
+  }
 
   t.end()
 })
@@ -312,10 +313,7 @@ test('leven', function (t) {
   t.is(leven('sturgeon', 'urgently'), 6)
   t.is(leven('levenshtein', 'frankenstein'), 6)
   t.is(leven('distance', 'difference'), 5)
-  t.is(
-    leven('因為我是中國人所以我會說中文', '因為我是英國人所以我會說英文'),
-    2
-  )
+  t.is(leven('因為我是中國人所以我會說中文', '因為我是英國人所以我會說英文'), 2)
   t.end()
 })
 


### PR DESCRIPTION
Closes https://github.com/mcollina/commist/issues/1

This could go out still in `v3`, however for the next major release, I'd change an API slightly, and make the return value of both `parse` and `parseAsync` pass provided arguments and generated output. Pseudo-shape:

```
type Arguments = string[]
type CommandResult = { output: unknown, args: Arguments }
type CommandError extends Error & {
  args: Arguments
}

throwable parse(args: Arguments): CommandResult | CommandError;
parseAsync(args: Arguments): Promise<CommandResult | CommandError>;
```

This way you can do `try/catch` for both APIs, and handle async code just by adding `await` before `parseAsync`.

```js
const program = require('commist')()

const syncProgram = program.register('port sync', (args) => getPort());

try {
  const port = syncProgram.parse(['db', 'potr']);
  console.log(`db running on port ${port}`);
} catch (err) {
  console.log(`invalid command ${err.args.join(' ')}`);
}

// and

const asyncProgram = program.register('port async', async (args) => getPortAsync());

try {
  const port = await asyncProgram.parseAsync(['db', 'potr']);
  console.log(`db running on port ${port}`);
} catch (err) {
  console.log(`invalid command ${err.args.join(' ')}`);
}
```